### PR TITLE
don't pass user-agent as a symbol

### DIFF
--- a/lib/eve_online/base.rb
+++ b/lib/eve_online/base.rb
@@ -40,7 +40,7 @@ module EveOnline
 
     def content
       @content ||= open(url, open_timeout: 60, read_timeout: 60,
-                             :'User-Agent' => user_agent).read
+                             'User-Agent' => user_agent).read
     end
 
     def response

--- a/spec/eve_online/base_spec.rb
+++ b/spec/eve_online/base_spec.rb
@@ -138,9 +138,9 @@ describe EveOnline::Base do
 
     before do
       #
-      # subject.open(url, open_timeout: 60, read_timeout: 60, :'User-Agent' => user_agent).read
+      # subject.open(url, open_timeout: 60, read_timeout: 60, 'User-Agent' => user_agent).read
       #
-      expect(subject).to receive(:open).with(url, open_timeout: 60, read_timeout: 60, :'User-Agent' => user_agent) do
+      expect(subject).to receive(:open).with(url, open_timeout: 60, read_timeout: 60, 'User-Agent' => user_agent) do
         double.tap do |a|
           expect(a).to receive(:read)
         end


### PR DESCRIPTION
Allows the gem to work on Rails 2.3.0. Needs tested on Ruby 1.9, since I can't get it compiled on my system for some reason. Resolves #3.